### PR TITLE
A proposed fix so that one does not have to make a copy of a document fro

### DIFF
--- a/memupdate/in-mem-update.xqy
+++ b/memupdate/in-mem-update.xqy
@@ -138,18 +138,26 @@ declare function mem:_process(
 	Constructs a node if need be and processes all of its children
 :)
 declare function mem:_processNode(
-	$node as node(),
-	$modifierNodes as node()*,
-	$newNode as node()*,
-	$mode as xs:string
+    $node as node(),
+    $modifierNodes as node()*,
+    $newNode as node()*,
+    $mode as xs:string
 ) as node()
 {
-	if($node instance of element(*))
-	then element { QName(namespace-uri($node), local-name($node)) } {
-		for $child in ($node/@*, $node/node())
-        return mem:_process($child, $modifierNodes, $newNode, $mode)
-
-	}
-	else $node
+    try {
+        if ($node instance of element(*)) then 
+            element { QName(namespace-uri($node), name($node)) } {
+                for $child in ($node/@*, $node/node())
+                return 
+                    mem:_process($child, $modifierNodes, $newNode, $mode)
+            }
+        else if (xdmp:node-kind($node) eq "document") then        
+            mem:_process($node/element(), $modifierNodes, $newNode, $mode)
+        else
+            $node
+    } catch ($error) {
+        xdmp:log($error),
+        $node
+    }
 };
 


### PR DESCRIPTION
A proposed fix so that one does not have to make a copy of a document from the database to modify it in-memory.  Search for "marklogic: document in-memory-update" in markmail.org to see details of problem (or http://markmail.org/search/?q=marklogic%3A%20document%20in-memory-update#query:marklogic%3A%20document%20in-memory-update+page:1+mid:4n6dmf52xmmiwhr7+state:results).

This seems to work, am I missing something?  Does this make it work better or is it more brittle and add any performance problems?
