### PR TITLE
Optimization of json.xqy functions

### DIFF
--- a/json/json.xqy
+++ b/json/json.xqy
@@ -19,13 +19,12 @@ xquery version "1.0-ml";
 module namespace json = "http://marklogic.com/json";
 declare default function namespace "http://www.w3.org/2005/xpath-functions";
 
+declare variable $new-line-regex := concat('[',codepoints-to-string((13, 10)),']+');
+
 (: Need to backslash escape any double quotes, backslashes, newlines and tabs :)
 declare function json:escape($s as xs:string) as xs:string {
-  let $s := replace($s, "\\", "\\\\")
-  let $s := replace($s, """", "\\""")
-  let $s := replace($s, codepoints-to-string((13, 10)), "\\n")
-  let $s := replace($s, codepoints-to-string(13), "\\n")
-  let $s := replace($s, codepoints-to-string(10), "\\n")
+  let $s := replace($s, "(\\|"")", "\\$1")
+  let $s := replace($s, $new-line-regex, "\\n")
   let $s := replace($s, codepoints-to-string(9), "\\t")
   return $s
 };
@@ -62,20 +61,19 @@ declare function json:print-value($x as element()) as xs:string {
 (: Print the name and value both :)
 declare function json:print-name-value($x as element()) as xs:string? {
   let $name := name($x)
-  let $first-in-array :=
-    count($x/preceding-sibling::*[name(.) = $name]) = 0 and
-    (count($x/following-sibling::*[name(.) = $name]) > 0 or $x/@array = "true")
-  let $later-in-array := count($x/preceding-sibling::*[name(.) = $name]) > 0
+  let $later-in-array := some $s in $x/following-sibling::* satisfies name($s) = $name
   return
-
   if ($later-in-array) then
-    ()  (: I was handled previously :)
-  else if ($first-in-array) then
-    string-join(('"', json:escape($name), '":[',
-      string-join((for $i in ($x, $x/following-sibling::*[name(.) = $name]) return json:print-value($i)), ","),
-    ']'), "")
-   else
-     string-join(('"', json:escape($name), '":', json:print-value($x)), "")
+    ()  (: I am going to be handled later :)
+  else 
+	let $preceding-siblings := $x/preceding-sibling::*[name(.) = $name]
+	let $last-in-array := ($x/@array = "true" or exists($preceding-siblings))
+	return if ($last-in-array) then
+		     string-join(('"', json:escape($name), '":[',
+      		   string-join((for $i in ($preceding-siblings, $x) return json:print-value($i)), ","),
+    	     ']'), "")
+   		   else
+             string-join(('"', json:escape($name), '":', json:print-value($x)), "")
 };
 
 (:~


### PR DESCRIPTION
I have optimized the json functions to reduce the time and the number of expressions evaluated. The major change was not evaluating $x/preceding-sibling::_[name(.) = $name] and $x/following-sibling::_[name(.) = $name] twice in some cases.

Also, made an alteration to json:escape to reduce the number of replace calls that are made.
